### PR TITLE
Notifier la configuration manquante uniquement sur un PAAS

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,32 +7,28 @@ module.exports = {
 
   contentFor(type, config) {
     if (type === 'head') {
-      if (config.matomo) {
-        if (!config.matomo.url) {
-          console.log(`[${moduleName}] No Matomo container URL has been defined in config/environment.js`);
-        } else {
-          const matomoUrl = config.matomo.url;
-          const debugMode = config.matomo.debug ? config.matomo.debug : false;
+      if (config.matomo && config.matomo.url) {
+        const matomoUrl = config.matomo.url;
+        const debugMode = config.matomo.debug ? config.matomo.debug : false;
 
-          let script = `
+        let script = `
 <!-- Matomo Tag Manager -->
 <script type="text/javascript">
 var _mtm = _mtm || [];`;
 
-          if (debugMode) {
-            script += `
-_mtm.push(['enableDebugMode']);`;
-          }
-
+        if (debugMode) {
           script += `
+_mtm.push(['enableDebugMode']);`;
+        }
+
+        script += `
 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
 g.type='text/javascript'; g.async=true; g.defer=true; g.src='${matomoUrl}'; s.parentNode.insertBefore(g,s);
 </script>
 <!-- End Matomo Tag Manager -->
 `;
-          return script;
-        }
+        return script;
       }
     }
   }


### PR DESCRIPTION
Lors de l'utilisation en local (ps dans CI ou review app), le message suivant est affiché
```
npm start
> mon-pix@2.231.0 start mon-pix
> ember serve --proxy http://localhost:3000
Proxying to http://localhost:3000
⠴ building... [broccoli-persistent-filter:EslintValidationFilter > applyPatches][ember-cli-matomo-tag-manager] No Matomo container URL has been defined in config/environment.js
[ember-cli-matomo-tag-manager] No Matomo container URL has been defined in config/environment.js
```

Or, la plupart  du temps, cela est une situation normale
La solution (pas optimale) est de ne l'afficher que sur les environements accessibles par un grand nombre d'utilisateurs.
Cela aura lieu sur un PAAS et dans ces cas-là, la variable `NODE_ENV` vaut `production`