### PR TITLE
Ne pas signaler au build que le package "ember-cli-matomo-tag-manager" n'est pas configuré

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,32 +7,28 @@ module.exports = {
 
   contentFor(type, config) {
     if (type === 'head') {
-      if (config.matomo) {
-        if (!config.matomo.url) {
-          console.log(`[${moduleName}] No Matomo container URL has been defined in config/environment.js`);
-        } else {
-          const matomoUrl = config.matomo.url;
-          const debugMode = config.matomo.debug ? config.matomo.debug : false;
+      if (config.matomo && config.matomo.url) {
+        const matomoUrl = config.matomo.url;
+        const debugMode = config.matomo.debug ? config.matomo.debug : false;
 
-          let script = `
+        let script = `
 <!-- Matomo Tag Manager -->
 <script type="text/javascript">
 var _mtm = _mtm || [];`;
 
-          if (debugMode) {
-            script += `
-_mtm.push(['enableDebugMode']);`;
-          }
-
+        if (debugMode) {
           script += `
+_mtm.push(['enableDebugMode']);`;
+        }
+
+        script += `
 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
 g.type='text/javascript'; g.async=true; g.defer=true; g.src='${matomoUrl}'; s.parentNode.insertBefore(g,s);
 </script>
 <!-- End Matomo Tag Manager -->
 `;
-          return script;
-        }
+        return script;
       }
     }
   }


### PR DESCRIPTION
## :unicorn: Problème
Lors du build d'une application
- utilisant le package `ember-cli-matomo-tag-manager `
- dont la configuration est incomplète (`config.matomo.url`)

Alors le message suivant est affiché` No Matomo container URL has been defined in config/environment.js`

Or, il existe des situations où le package n'est pas utilisé: local, CI, review app
Cela risque de porter le développeur à ignorer tous les messages du build en local, dont ceux qui ne concernent pas ce package.

## :robot: Solution
La solution est de ne pas afficher d'avertissement.
Si l'utilisateur n'a pas correctement configuré le plugin, il s'en rendra compte par d'autres moyens.