### PR TITLE
Faciliter la création de CSP malgré l'usage de ce module

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@ module.exports = {
       const matomoUrl = config.matomo.url;
       const debugMode = config.matomo.debug ? config.matomo.debug : false;
 
-      let loadMatomoScript = `<!-- Matomo Tag Manager -->
+      const loadMatomoScript = `<!-- Matomo Tag Manager -->
       <script type="text/javascript" async defer src="${matomoUrl}"></script>`;
 
-      let startEventScript = `
+      const startEventScript = `
         <script id="start-matomo-event" type="text/javascript" src="/ember-cli-matomo-tag-manager/start-matomo-event.js" data-debug-mode="${debugMode}"></script>
         <!-- End Matomo Tag Manager -->`;
 

--- a/index.js
+++ b/index.js
@@ -11,24 +11,22 @@ module.exports = {
         const matomoUrl = config.matomo.url;
         const debugMode = config.matomo.debug ? config.matomo.debug : false;
 
-        let script = `
-<!-- Matomo Tag Manager -->
-<script type="text/javascript">
-var _mtm = _mtm || [];`;
+        let startEventScript = `<!-- Matomo Tag Manager -->
+          <script type="text/javascript">
+          var _mtm = _mtm || [];`;
 
-        if (debugMode) {
-          script += `
-_mtm.push(['enableDebugMode']);`;
-        }
+        startEventScript += debugMode ? `\n _mtm.push(['enableDebugMode']);` : '';
 
-        script += `
-_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-g.type='text/javascript'; g.async=true; g.defer=true; g.src='${matomoUrl}'; s.parentNode.insertBefore(g,s);
-</script>
-<!-- End Matomo Tag Manager -->
-`;
-        return script;
+        startEventScript += `
+          _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+          </script>`;
+
+        let loadMatomoScript = `
+          <script type="text/javascript" async defer src="${matomoUrl}"></script>
+          <!-- End Matomo Tag Manager -->
+          `;
+
+        return startEventScript + loadMatomoScript;
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -10,22 +10,14 @@ module.exports = {
       const matomoUrl = config.matomo.url;
       const debugMode = config.matomo.debug ? config.matomo.debug : false;
 
-      let startEventScript = `<!-- Matomo Tag Manager -->
-        <script type="text/javascript">
-        var _mtm = _mtm || [];`;
+      let loadMatomoScript = `<!-- Matomo Tag Manager -->
+      <script type="text/javascript" async defer src="${matomoUrl}"></script>`;
 
-      startEventScript += debugMode ? `\n _mtm.push(['enableDebugMode']);` : '';
+      let startEventScript = `
+        <script id="start-matomo-event" type="text/javascript" src="/ember-cli-matomo-tag-manager/start-matomo-event.js" data-debug-mode="${debugMode}"></script>
+        <!-- End Matomo Tag Manager -->`;
 
-      startEventScript += `
-        _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-        </script>`;
-
-      let loadMatomoScript = `
-        <script type="text/javascript" async defer src="${matomoUrl}"></script>
-        <!-- End Matomo Tag Manager -->
-        `;
-
-      return startEventScript + loadMatomoScript;
+      return loadMatomoScript + startEventScript;
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -6,28 +6,26 @@ module.exports = {
   name: moduleName,
 
   contentFor(type, config) {
-    if (type === 'head') {
-      if (config.matomo && config.matomo.url) {
-        const matomoUrl = config.matomo.url;
-        const debugMode = config.matomo.debug ? config.matomo.debug : false;
+    if (type === 'head' && config.matomo && config.matomo.url) {
+      const matomoUrl = config.matomo.url;
+      const debugMode = config.matomo.debug ? config.matomo.debug : false;
 
-        let startEventScript = `<!-- Matomo Tag Manager -->
-          <script type="text/javascript">
-          var _mtm = _mtm || [];`;
+      let startEventScript = `<!-- Matomo Tag Manager -->
+        <script type="text/javascript">
+        var _mtm = _mtm || [];`;
 
-        startEventScript += debugMode ? `\n _mtm.push(['enableDebugMode']);` : '';
+      startEventScript += debugMode ? `\n _mtm.push(['enableDebugMode']);` : '';
 
-        startEventScript += `
-          _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
-          </script>`;
+      startEventScript += `
+        _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+        </script>`;
 
-        let loadMatomoScript = `
-          <script type="text/javascript" async defer src="${matomoUrl}"></script>
-          <!-- End Matomo Tag Manager -->
-          `;
+      let loadMatomoScript = `
+        <script type="text/javascript" async defer src="${matomoUrl}"></script>
+        <!-- End Matomo Tag Manager -->
+        `;
 
-        return startEventScript + loadMatomoScript;
-      }
+      return startEventScript + loadMatomoScript;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "author": "Pix",
   "maintainers": [
-    "Jérémy Buger (https://github.com/jbuget)"
+    "Jérémy Buget (https://github.com/jbuget)"
   ],
   "directories": {
     "doc": "doc",

--- a/public/start-matomo-event.js
+++ b/public/start-matomo-event.js
@@ -1,0 +1,9 @@
+var _mtm = _mtm || [];
+
+const isDebugMode = document.getElementById('start-matomo-event').getAttribute('data-debug-mode');
+
+if (isDebugMode) {
+  _mtm.push(['enableDebugMode']);
+} 
+
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});


### PR DESCRIPTION
# 📦  Problème 

Comme mentionné dans l'issue : #13 , l'utilisation de blocs `script` rend la création de Content Security Policy robuste difficile.

# 🌮 Solution 

En suivant les recommandations faites dans l'issue : 
- Retirer la création d'une balise de façon dynamique pour charger le script de Matomo.
- Extraction du script permettant d'effectuer le : `mtm.Start` dans le dossier `/public` comme recommandé dans [la documentation Ember](https://cli.emberjs.com/release/writing-addons/#public). 

En plus : 
 - Fix d'une typo 
 - Suppression d'indentation inutile.