### PR TITLE
[BUGFIX] Permettre de désactiver le mode Debug. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
       <script type="text/javascript" async defer src="${matomoUrl}"></script>`;
 
       const startEventScript = `
-        <script id="start-matomo-event" type="text/javascript" src="/ember-cli-matomo-tag-manager/start-matomo-event.js" data-debug-mode="${debugMode}"></script>
+        <script type="text/javascript" src="/ember-cli-matomo-tag-manager/start-matomo-event.js" data-matomo-debug-mode="${debugMode}"></script>
         <!-- End Matomo Tag Manager -->`;
 
       return loadMatomoScript + startEventScript;

--- a/public/start-matomo-event.js
+++ b/public/start-matomo-event.js
@@ -1,8 +1,6 @@
 var _mtm = _mtm || [];
 
-const isDebugMode = document.getElementById('start-matomo-event').getAttribute('data-debug-mode');
-
-if (isDebugMode) {
+if (document.querySelector('script[data-matomo-debug-mode="true"]')) {
   _mtm.push(['enableDebugMode']);
 } 
 


### PR DESCRIPTION
# :unicorn: Problème 
Depuis #14 , le mode debug est activé dans tous les cas, à cause du `debugMode="false"` => qui correspond donc à un chaine de caractère et non pas à un booléen. 

# 🌮  Solution 
Utiliser une solution plus robuste pour tester cela : 
`document.querySelector('script[data-matomo-debug-mode="true"]')`